### PR TITLE
[SPARK-32947] Support top-N sort for Spark SQL window function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -373,7 +373,7 @@ object UnsupportedOperationChecker extends Logging {
         case Sample(_, _, _, _, child) if child.isStreaming =>
           throwError("Sampling is not supported on streaming DataFrames/Datasets")
 
-        case Window(_, _, _, child) if child.isStreaming =>
+        case Window(_, _, _, _, child) if child.isStreaming =>
           throwError("Non-time-based windows are not supported on streaming DataFrames/Datasets")
 
         case ReturnAnswer(child) if child.isStreaming =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -392,7 +392,7 @@ package object dsl {
           windowExpressions: Seq[NamedExpression],
           partitionSpec: Seq[Expression],
           orderSpec: Seq[SortOrder]): LogicalPlan =
-        Window(windowExpressions, partitionSpec, orderSpec, logicalPlan)
+        Window(windowExpressions, partitionSpec, orderSpec, null, logicalPlan)
 
       def subquery(alias: Symbol): LogicalPlan = SubqueryAlias(alias.name, logicalPlan)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -773,3 +773,22 @@ case class PercentRank(children: Seq[Expression]) extends RankLike with SizeBase
     If(n > one, (rank - one).cast(DoubleType) / (n - one).cast(DoubleType), 0.0d)
   override def prettyName: String = "percent_rank"
 }
+
+/**
+ * This class represents the rank limit of a window rank function.
+ * The rankPrettyName could be "rank", "dense_rank" or "percent_rank".
+ */
+case class RankLimit(
+    rankPrettyName: Option[String],
+    rankLimit: Int) {
+  require(rankPrettyName.exists(_.trim.nonEmpty), "rankPrettyName must be non-empty strings")
+  require(rankLimit > 0, "rankLimit must be positive integers")
+
+  def getRankPrettyName(): String = {
+    rankPrettyName.getOrElse("").trim
+  }
+
+  def getRankLimit(): Int = {
+    rankLimit
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -362,12 +362,13 @@ object PhysicalAggregation {
  * the rule ExtractWindowExpressions in the analyzer.
  */
 object PhysicalWindow {
-  // windowFunctionType, windowExpression, partitionSpec, orderSpec, child
-  private type ReturnType =
-    (WindowFunctionType, Seq[NamedExpression], Seq[Expression], Seq[SortOrder], LogicalPlan)
+  // windowFunctionType, windowExpression, partitionSpec, orderSpec, rankLimit, child
+  private type ReturnType = (
+    WindowFunctionType, Seq[NamedExpression], Seq[Expression],
+    Seq[SortOrder], RankLimit, LogicalPlan)
 
   def unapply(a: Any): Option[ReturnType] = a match {
-    case expr @ logical.Window(windowExpressions, partitionSpec, orderSpec, child) =>
+    case expr @ logical.Window(windowExpressions, partitionSpec, orderSpec, rankLimit, child) =>
 
       // The window expression should not be empty here, otherwise it's a bug.
       if (windowExpressions.isEmpty) {
@@ -385,7 +386,7 @@ object PhysicalWindow {
           }
         }
 
-      Some((windowFunctionType, windowExpressions, partitionSpec, orderSpec, child))
+      Some((windowFunctionType, windowExpressions, partitionSpec, orderSpec, rankLimit, child))
 
     case _ => None
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -621,7 +621,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite {
   testUnaryOperatorInStreamingPlan(
     "sample", Sample(0.1, 1, true, 1L, _), expectedMsg = "sampling")
   testUnaryOperatorInStreamingPlan(
-    "window", Window(Nil, Nil, Nil, _), expectedMsg = "non-time-based windows")
+    "window", Window(Nil, Nil, Nil, null, _), expectedMsg = "non-time-based windows")
 
   // Output modes with aggregation and non-aggregation plans
   testOutputMode(Append, shouldSupportAggregation = false, shouldSupportNonAggregation = true)

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowTopNRankSorter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowTopNRankSorter.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Stack;
+
+import scala.Tuple2;
+import scala.collection.Iterator;
+import scala.math.Ordering;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.RankLimit;
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.types.StructType;
+
+public final class UnsafeExternalRowTopNRankSorter extends UnsafeExternalRowTopNSorter {
+
+  private int topRank;
+
+  public static UnsafeExternalRowTopNRankSorter create(
+    StructType schema,
+    Ordering<InternalRow> orderingInWindow,
+    int rankLimit) {
+    return new UnsafeExternalRowTopNRankSorter(
+      schema, orderingInWindow, rankLimit);
+  }
+
+  private UnsafeExternalRowTopNRankSorter(
+      StructType schema,
+      Ordering<InternalRow> orderingInWindow,
+      int rankLimit) {
+    super(schema, orderingInWindow, rankLimit);
+    // This parameter records the rank of the top row (head node) in the heap
+    this.topRank = 0;
+  }
+
+  /* We count the number of rows that are the same as the head of the heap. Then the remaining
+   * rows that are not counted yet are all less than the head of the heap. So we update the
+   * rank of the heap top to be the number of uncounted rows in the heap plus one.
+   */
+  void reCalculateTopRank() {
+    Queue<UnsafeRow> topRowBuffer = new LinkedList<UnsafeRow>();
+    UnsafeRow top = heap.peek();
+    UnsafeRow newTop = heap.peek();
+    while (newTop != null && unsafeRowComparator.compare(top, newTop) == 0) {
+      heap.poll();
+      topRowBuffer.add(newTop);
+      newTop = heap.peek();
+    }
+    topRank = heap.size() + 1;
+    while (!topRowBuffer.isEmpty()) {
+      top = topRowBuffer.peek();
+      topRowBuffer.remove();
+      heap.add(top);
+    }
+  }
+
+  @Override
+  public void insertRow(UnsafeRow row) throws IOException {
+    long start = System.nanoTime();
+    boolean addToHeap = false;
+    UnsafeRow top = heap.peek();
+
+    /* We define the final row returned by the sorter as the row with the maximum weight.
+     * We maintain a max heap, which means the top of the heap has the maximum weight. 
+     * If the new row is equal to the top of the heap, we always insert it, the rank
+     * of the top is not affected after the insertion;
+     * If the new row is greater than the top of the heap, the insertion will only happen
+     * when the heap is not full yet and after the insertion the newly inserted row will
+     * become the new head and the rank of new head will be updated to the existing heap
+     * size plus one.
+     * If the new row is less than the top of the heap, we always insert it, the head
+     * of the heap needs to be removed if the heap reaches the rank limit.
+     * Any insertion will cause the increase of the rank of the next potential new head.
+     */
+    if (top == null) {
+      addToHeap = true;
+      topRank = topRank + 1;
+    }
+    else if (unsafeRowComparator.compare(row, top) == 0) { // equal to the top
+      addToHeap = true;
+    } else if (unsafeRowComparator.compare(row, top) < 0) { // less than the top
+      addToHeap = true;
+      topRank = topRank + 1;
+    } else { // greater than the top
+      int nextRank = heap.size() + 1;
+      if (nextRank <= rankLimit) {
+        addToHeap = true;
+        topRank = nextRank;
+      }
+    }
+
+    if (rankLimit == 0 || !addToHeap) {
+      return;
+    }
+
+    UnsafeRow rowCopy = row.copy();
+    heap.add(rowCopy);
+
+    if (topRank > rankLimit) {
+      UnsafeRow newTop = heap.peek();
+      while (unsafeRowComparator.compare(top, newTop) == 0) {
+        heap.poll();
+        newTop = heap.peek();
+      }
+      // We remove the old top and now we have a new top. So we need to re-calculate
+      // the rank of the new top.
+      reCalculateTopRank();
+    }
+
+    totalSortTimeNanos += System.nanoTime() - start;
+  }
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowTopNSorter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeExternalRowTopNSorter.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Stack;
+
+import scala.Tuple2;
+import scala.collection.Iterator;
+import scala.math.Ordering;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.RankLimit;
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.types.StructType;
+
+public abstract class UnsafeExternalRowTopNSorter extends AbstractUnsafeExternalRowSorter {
+
+  private final StructType schema;
+  protected final Comparator<UnsafeRow> unsafeRowComparator;
+  protected final PriorityQueue<UnsafeRow> heap;
+  protected final int rankLimit;
+  protected long totalSortTimeNanos = 0L;
+
+  protected UnsafeExternalRowTopNSorter(
+      StructType schema,
+      Ordering<InternalRow> orderingInWindow,
+      int rankLimit) {
+    this.schema = schema;
+    this.unsafeRowComparator = new UnsafeRowComparator(orderingInWindow);
+    this.heap = new PriorityQueue<UnsafeRow>(
+      rankLimit, this.unsafeRowComparator.reversed());
+    this.rankLimit = rankLimit;
+  }
+
+  @Override
+  public Iterator<InternalRow> sort() throws IOException {
+    long start = System.nanoTime();
+    int heapSize = heap.size();
+    Stack<UnsafeRow> stack = new Stack<UnsafeRow>();
+    for (int i = 0; i < heapSize; i++) {
+      UnsafeRow top = heap.peek();
+      stack.push(top);
+      heap.poll();
+    }
+
+    TopNSortIterator topNSortIterator = new TopNSortIterator(stack);
+    totalSortTimeNanos += System.nanoTime() - start;
+    return topNSortIterator.toScala();
+  }
+
+  @Override
+  public Iterator<InternalRow> sort(Iterator<UnsafeRow> inputIterator) throws IOException {
+    while (inputIterator.hasNext()) {
+      insertRow(inputIterator.next());
+    }
+    return sort();
+  }
+
+  @Override
+  public Iterator<InternalRow> getIterator() throws IOException {
+    throw new IOException("This method is not supported.");
+  }
+
+  @Override
+  public long getPeakMemoryUsage() {
+    return 0;
+  }
+
+  @Override
+  public long getSortTimeNanos() {
+    return totalSortTimeNanos;
+  }
+
+  @Override
+  public void cleanupResources() {
+    return;
+  }
+
+  @Override
+  void setTestSpillFrequency(int frequency) {
+    return;
+  }
+
+  private static final class UnsafeRowComparator
+    implements Comparator<UnsafeRow> {
+
+    private final Ordering<InternalRow> ordering;
+
+    UnsafeRowComparator(
+      Ordering<InternalRow> ordering) {
+      this.ordering = ordering;
+    }
+
+    @Override
+    public int compare(UnsafeRow r1, UnsafeRow r2) {
+      return this.ordering.compare(r1, r2);
+    }
+  }
+
+  private static final class TopNSortIterator extends RowIterator {
+
+    Stack<UnsafeRow> stack;
+
+    TopNSortIterator(Stack<UnsafeRow> stack) {
+      this.stack = stack;
+      // Add a pad for start. The first call of
+      // advanceNext will get rid of this pad.
+      this.stack.push(null);
+    }
+
+    @Override
+    public boolean advanceNext() {
+      this.stack.pop();
+      return !this.stack.isEmpty();
+    }
+
+    @Override
+    public UnsafeRow getRow() {
+      return this.stack.peek();
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -84,6 +84,7 @@ case class WindowSortExec(
     sortOrderAcrossWindows: Seq[SortOrder],
     global: Boolean,
     child: SparkPlan,
+    rankLimit: RankLimit = null,
     testSpillFrequency: Int = 0)
   extends SortExecBase(
     sortOrderAcrossWindows,
@@ -122,7 +123,8 @@ case class WindowSortExec(
         prefixComputer,
         false,
         canUseRadixSort,
-        pageSize)
+        pageSize,
+        null)
     } else {
       // Generate the bound expression in a window
       val boundSortExpressionInWindow = BindReferences.bindReference(
@@ -157,7 +159,8 @@ case class WindowSortExec(
         prefixComputer,
         canUseRadixSortInWindow,
         canUseRadixSort,
-        pageSize)
+        pageSize,
+        rankLimit)
     }
 
     if (testSpillFrequency > 0) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -515,14 +515,14 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
   object Window extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case PhysicalWindow(
-        WindowFunctionType.SQL, windowExprs, partitionSpec, orderSpec, child) =>
+        WindowFunctionType.SQL, windowExprs, partitionSpec, orderSpec, rankLimit, child) =>
         execution.window.WindowExec(
-          windowExprs, partitionSpec, orderSpec, planLater(child)) :: Nil
+          windowExprs, partitionSpec, orderSpec, rankLimit, planLater(child)) :: Nil
 
       case PhysicalWindow(
-        WindowFunctionType.Python, windowExprs, partitionSpec, orderSpec, child) =>
+        WindowFunctionType.Python, windowExprs, partitionSpec, orderSpec, rankLimit, child) =>
         execution.python.WindowInPandasExec(
-          windowExprs, partitionSpec, orderSpec, planLater(child)) :: Nil
+          windowExprs, partitionSpec, orderSpec, rankLimit, planLater(child)) :: Nil
 
       case _ => Nil
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -126,13 +126,14 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
         child
       } else {
         operator match {
-          case WindowExec(_, partitionSpec, orderSpec, _)
-            if (!partitionSpec.isEmpty && !orderSpec.isEmpty) =>
+          case WindowExec(_, partitionSpec, orderSpec, rankLimit, _)
+              if (!partitionSpec.isEmpty && !orderSpec.isEmpty) =>
             WindowSortExec(
               partitionSpec,
               orderSpec,
               requiredOrdering,
               global = false,
+              rankLimit = rankLimit,
               child = child)
           case _ =>
             SortExec(requiredOrdering, global = false, child = child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/WindowInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/WindowInPandasExec.scala
@@ -83,6 +83,7 @@ case class WindowInPandasExec(
     windowExpression: Seq[NamedExpression],
     partitionSpec: Seq[Expression],
     orderSpec: Seq[SortOrder],
+    rankLimit: RankLimit,
     child: SparkPlan)
   extends WindowExecBase {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExec.scala
@@ -92,6 +92,7 @@ case class WindowExec(
     windowExpression: Seq[NamedExpression],
     partitionSpec: Seq[Expression],
     orderSpec: Seq[SortOrder],
+    rankLimit: RankLimit,
     child: SparkPlan)
   extends WindowExecBase {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -677,6 +677,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
       Seq(attribute1),
       partitionSpec,
       orderSpec,
+      null,
       child = childPlan)
 
     val outputPlan = EnsureRequirements(spark.sessionState.conf).apply(inputPlan)


### PR DESCRIPTION
### What changes were proposed in this pull request?
We add a new parameter rankLimit in the operator Window and WindowSortExec, and the parameter rankLimit is null by default. We parse the filter above the Window operator to set the rankLimit if there is any filter specified for the window rank. We conduct TopN sort if the rankLimit is found.


### Why are the changes needed?
This PR gives performance gain to SQL window sort when a filter of the window rank is provided by a user. With the code change in this PR, the query 67 in TPCDS-10TB benchmark can run 4X~5X faster.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
It is tested by the existing unit tests and the newly added unit tests.
